### PR TITLE
refactor: Remove authz

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-authz/core": "^1.3.1",
-        "@graphql-authz/envelop-plugin": "^1.0.5",
         "@pothos/core": "^4.1.0",
-        "@pothos/plugin-authz": "^3.5.10",
         "@pothos/plugin-scope-auth": "^4.1.0",
         "axios": "^1.7.3",
         "gql.tada": "^1.8.5",
@@ -1236,27 +1233,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@envelop/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@envelop/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-ZxeQs4G0FOzoFAH+zskubx5aM9kx6BiUvcSI9Lo3MfYBmnK7cjwcwDdwk6Mq48QDuAeVdGfDmQz+BiWg0k2GmQ==",
-      "peer": true,
-      "dependencies": {
-        "@envelop/types": "1.5.1"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@envelop/types": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@envelop/types/-/types-1.5.1.tgz",
-      "integrity": "sha512-NrwLVzyNqiSzgRRqOxkU2IgRc5hSGS73VsgxqchU3jl36rYo7AXVAnITkytmB9wk+jN2vUOVvayLkaTXooARwg==",
-      "peer": true,
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -1660,25 +1636,6 @@
       "peerDependencies": {
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
         "typescript": "^5.0.0"
-      }
-    },
-    "node_modules/@graphql-authz/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-authz/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-fF3H9NXiDjF1uZgLYtjjv0j4JFeJgaVRCWg7WgcXmxh5hq5y8wRIK29twgZVpURggXMsZid9EzEu5LY1pH2utw==",
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-authz/envelop-plugin": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-authz/envelop-plugin/-/envelop-plugin-1.0.5.tgz",
-      "integrity": "sha512-wHeNB8ZdO5DEw3tK7V1/gI6aFyugCNLEAM3KL1dsSWsOJMgBW/i85dTf88L8yL+o83EkLQgW0DKWw+6eEO2p7w==",
-      "dependencies": {
-        "@graphql-authz/core": "1.3.1"
-      },
-      "peerDependencies": {
-        "@envelop/core": "^1.0.3"
       }
     },
     "node_modules/@graphql-codegen/add": {
@@ -2627,15 +2584,6 @@
       "integrity": "sha512-EH9Gop2r09OUvDzWuIgB4mJhwgCU5R/U9gGRNt5I+ORFyc5EuxG0RLWJiOds6mcwm7DvggMegnTaU88N/M2SJw==",
       "peerDependencies": {
         "graphql": ">=16.6.0"
-      }
-    },
-    "node_modules/@pothos/plugin-authz": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/@pothos/plugin-authz/-/plugin-authz-3.5.10.tgz",
-      "integrity": "sha512-HIrz72+KnbvJjRKEtuy+c/J69jxET/yiSKLx/q3IV8FC4GyPKnPxlwuGlMczxlpK6+UG0gE0ziCAwY6LWEd2Yg==",
-      "peerDependencies": {
-        "@graphql-authz/core": "*",
-        "graphql": ">=15.1.0"
       }
     },
     "node_modules/@pothos/plugin-scope-auth": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@graphql-authz/envelop-plugin": "^1.0.5",
         "@pothos/core": "^4.1.0",
         "@pothos/plugin-authz": "^3.5.10",
+        "@pothos/plugin-scope-auth": "^4.1.0",
         "axios": "^1.7.3",
         "gql.tada": "^1.8.5",
         "graphql": "^16.9.0",
@@ -2635,6 +2636,15 @@
       "peerDependencies": {
         "@graphql-authz/core": "*",
         "graphql": ">=15.1.0"
+      }
+    },
+    "node_modules/@pothos/plugin-scope-auth": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@pothos/plugin-scope-auth/-/plugin-scope-auth-4.1.0.tgz",
+      "integrity": "sha512-xSMV7xHZAahGmtYEoibjBgJ7Y6v6GSALOt3ZS2lZMaPKuoPFf9uz4r8N0ecz2lopwHH1u88f7thN+kgurqUvtw==",
+      "peerDependencies": {
+        "@pothos/core": "*",
+        "graphql": ">=16.6.0"
       }
     },
     "node_modules/@repeaterjs/repeater": {

--- a/package.json
+++ b/package.json
@@ -45,10 +45,7 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
-    "@graphql-authz/core": "^1.3.1",
-    "@graphql-authz/envelop-plugin": "^1.0.5",
     "@pothos/core": "^4.1.0",
-    "@pothos/plugin-authz": "^3.5.10",
     "@pothos/plugin-scope-auth": "^4.1.0",
     "axios": "^1.7.3",
     "gql.tada": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@graphql-authz/envelop-plugin": "^1.0.5",
     "@pothos/core": "^4.1.0",
     "@pothos/plugin-authz": "^3.5.10",
+    "@pothos/plugin-scope-auth": "^4.1.0",
     "axios": "^1.7.3",
     "gql.tada": "^1.8.5",
     "graphql": "^16.9.0",

--- a/src/auth/rules/IsAdmin.ts
+++ b/src/auth/rules/IsAdmin.ts
@@ -1,6 +1,0 @@
-import { preExecRule } from "@graphql-authz/core";
-import { Context } from "../../schema/context.js";
-
-export const IsAdmin = preExecRule({
-  error: "You must be an admin to access this resource.",
-})((context: Context) => context.user.type === "ADMIN");

--- a/src/auth/rules/index.ts
+++ b/src/auth/rules/index.ts
@@ -1,5 +1,0 @@
-import { IsAdmin } from "./IsAdmin.js";
-
-export const rules = {
-  IsAdmin,
-};

--- a/src/schema/auth/unauthorizedError.ts
+++ b/src/schema/auth/unauthorizedError.ts
@@ -1,0 +1,36 @@
+import {
+  AuthScopeFailureType,
+  UnauthorizedForTypeErrorFn,
+} from "@pothos/plugin-scope-auth";
+import { GraphQLErrorOptions, GraphQLError } from "graphql";
+import { SchemaTypes } from "../types.js";
+
+export const unauthorizedError: UnauthorizedForTypeErrorFn<
+  PothosSchemaTypes.ExtendDefaultTypes<SchemaTypes>,
+  {}
+> = (_, __, ___, { failure, message }) => {
+  const options: GraphQLErrorOptions = {
+    extensions: {
+      code: "FORBIDDEN",
+    },
+  };
+
+  if (failure.kind === AuthScopeFailureType.AnyAuthScopes) {
+    const scopes = failure.failures.reduce<string[]>((acc, f) => {
+      if (f.kind === AuthScopeFailureType.AuthScope) {
+        return acc.concat(f.scope);
+      } else {
+        return acc;
+      }
+    }, []);
+
+    return new GraphQLError(
+      `${message}. Must have ${scopes.join(", ")} scope${
+        scopes.length > 1 ? "s" : ""
+      }`,
+      options
+    );
+  }
+
+  return new GraphQLError(message, options);
+};

--- a/src/schema/builder.ts
+++ b/src/schema/builder.ts
@@ -1,16 +1,12 @@
 import SchemaBuilder from "@pothos/core";
 import ScopeAuthPlugin from "@pothos/plugin-scope-auth";
+import { SchemaTypes } from "./types.js";
+import { unauthorizedError } from "./auth/unauthorizedError.js";
 
-import { Context } from "./context.js";
-
-export const builder = new SchemaBuilder<{
-  Context: Context;
-  AuthScopes: {
-    admin: boolean;
-  };
-}>({
+export const builder = new SchemaBuilder<SchemaTypes>({
   plugins: [ScopeAuthPlugin],
   scopeAuth: {
+    unauthorizedError,
     authScopes: async (context) => ({
       admin: context.user.type === "ADMIN",
     }),

--- a/src/schema/builder.ts
+++ b/src/schema/builder.ts
@@ -1,12 +1,18 @@
 import SchemaBuilder from "@pothos/core";
-import AuthzPlugin from "@pothos/plugin-authz";
+import ScopeAuthPlugin from "@pothos/plugin-scope-auth";
 
 import { Context } from "./context.js";
-import { rules } from "../auth/rules/index.js";
 
 export const builder = new SchemaBuilder<{
   Context: Context;
-  AuthZRule: keyof typeof rules;
+  AuthScopes: {
+    admin: boolean;
+  };
 }>({
-  plugins: [AuthzPlugin],
+  plugins: [ScopeAuthPlugin],
+  scopeAuth: {
+    authScopes: async (context) => ({
+      admin: context.user.type === "ADMIN",
+    }),
+  },
 });

--- a/src/schema/mutations/createCharacter.ts
+++ b/src/schema/mutations/createCharacter.ts
@@ -31,8 +31,8 @@ const CreateCharacterInput = builder.inputType("CreateCharacterInput", {
 builder.mutationField("createCharacter", (t) =>
   t.field({
     type: Character,
-    authz: {
-      rules: ["IsAdmin"],
+    authScopes: {
+      admin: true,
     },
     args: {
       input: t.arg({

--- a/src/schema/mutations/updateToa.ts
+++ b/src/schema/mutations/updateToa.ts
@@ -23,8 +23,8 @@ const UpdateToaInput = builder.inputType("UpdateToaInput", {
 builder.mutationField("updateToa", (t) =>
   t.field({
     type: Toa,
-    authz: {
-      rules: ["IsAdmin"],
+    authScopes: {
+      admin: true,
     },
     args: {
       input: t.arg({

--- a/src/schema/mutations/updateTuraga.ts
+++ b/src/schema/mutations/updateTuraga.ts
@@ -24,8 +24,8 @@ const UpdateTuragaInput = builder.inputType("UpdateTuragaInput", {
 builder.mutationField("updateTuraga", (t) =>
   t.field({
     type: Turaga,
-    authz: {
-      rules: ["IsAdmin"],
+    authScopes: {
+      admin: true,
     },
     args: {
       input: t.arg({

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -1,0 +1,8 @@
+import { Context } from "./context.js";
+
+export type SchemaTypes = {
+  Context: Context;
+  AuthScopes: {
+    admin: boolean;
+  };
+};

--- a/src/yoga.ts
+++ b/src/yoga.ts
@@ -1,18 +1,11 @@
 import "@total-typescript/ts-reset";
 
-import { authZEnvelopPlugin } from "@graphql-authz/envelop-plugin";
 import { createYoga } from "graphql-yoga";
 
 import { schema } from "./schema/index.js";
 import { context } from "./schema/context.js";
-import { rules } from "./auth/rules/index.js";
 
 export const yoga = createYoga({
   schema,
   context,
-  plugins: [
-    authZEnvelopPlugin({
-      rules,
-    }),
-  ],
 });

--- a/tests/character.test.ts
+++ b/tests/character.test.ts
@@ -292,11 +292,11 @@ describe("Character mutations", () => {
 
     assertSingleValue(result);
 
-    expect(result.data).toBeUndefined();
+    expect(result.data).toEqual({ createCharacter: null });
     expect(result.errors).toHaveLength(1);
     expect(result.errors?.[0].extensions).toEqual({ code: "FORBIDDEN" });
     expect(result.errors?.[0].message).toEqual(
-      "You must be an admin to access this resource."
+      "Not authorized to resolve Mutation.createCharacter. Must have admin scope"
     );
   });
 });

--- a/tests/toa.test.ts
+++ b/tests/toa.test.ts
@@ -117,11 +117,11 @@ describe("Toa mutations", () => {
 
     assertSingleValue(result);
 
-    expect(result.data).toBeUndefined();
+    expect(result.data).toEqual({ updateToa: null });
     expect(result.errors).toHaveLength(1);
     expect(result.errors?.[0].extensions).toEqual({ code: "FORBIDDEN" });
     expect(result.errors?.[0].message).toEqual(
-      "You must be an admin to access this resource."
+      "Not authorized to resolve Mutation.updateToa. Must have admin scope"
     );
   });
 });

--- a/tests/turaga.test.ts
+++ b/tests/turaga.test.ts
@@ -116,11 +116,11 @@ describe("Turaga mutations", () => {
 
     assertSingleValue(result);
 
-    expect(result.data).toBeUndefined();
+    expect(result.data).toEqual({ updateTuraga: null });
     expect(result.errors).toHaveLength(1);
     expect(result.errors?.[0].extensions).toEqual({ code: "FORBIDDEN" });
     expect(result.errors?.[0].message).toEqual(
-      "You must be an admin to access this resource."
+      "Not authorized to resolve Mutation.updateTuraga. Must have admin scope"
     );
   });
 });


### PR DESCRIPTION
The Pothose AuthZ plugin has been deprecated due to the AuthZ module not being maintained. This PR replaces it with the standard [`scope-auth` plugin](https://pothos-graphql.dev/docs/plugins/scope-auth)